### PR TITLE
Use a valid name for the pvc-size value

### DIFF
--- a/charts/osbuilder/Chart.yaml
+++ b/charts/osbuilder/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
 - name: Ettore Di Giacinto
   email: mudler@kairos.io
 
-version: 0.5.1
+version: 0.5.2
 appVersion: "v0.5.1"

--- a/charts/osbuilder/templates/nginx-pvc.yaml
+++ b/charts/osbuilder/templates/nginx-pvc.yaml
@@ -9,4 +9,4 @@ spec:
       - ReadWriteOnce
     resources:
         requests:
-            storage: {{ .Values.nginx.pvc-size }}
+            storage: '{{ .Values.nginx.pvcSize }}'

--- a/charts/osbuilder/values.yaml
+++ b/charts/osbuilder/values.yaml
@@ -34,7 +34,7 @@ tls:
   certManagerIssuerName: ""
 
 nginx:
-  pvc-size: 3Gi
+  pvcSize: 3Gi
 
 ## Resource limits & requests
 ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
because this creates the error:

bad character U+002D '-'

Signed-off-by: Dimitris Karakasilis <dimitris@karakasilis.me>