### PR TITLE
Use a unique name for the nginx Deployment

### DIFF
--- a/charts/osbuilder/Chart.yaml
+++ b/charts/osbuilder/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
 - name: Ettore Di Giacinto
   email: mudler@kairos.io
 
-version: 0.5.2
+version: 0.5.3
 appVersion: "v0.5.1"

--- a/charts/osbuilder/templates/deployment.yaml
+++ b/charts/osbuilder/templates/deployment.yaml
@@ -98,7 +98,7 @@ kind: Deployment
 metadata:
     labels:
         app.kubernetes.io/name: osbuilder-nginx
-    name: '{{ include "helm-chart.fullname" . }}'
+    name: 'osbuilder-nginx'
     namespace: '{{.Release.Namespace}}'
 spec:
     replicas: 1


### PR DESCRIPTION
because the currently used one was also used for the osbuilder controller Deployment

Signed-off-by: Dimitris Karakasilis <dimitris@karakasilis.me>