### PR TITLE
Bump kcrypt-challenger to 0.6.0

### DIFF
--- a/charts/kcrypt-challenger/Chart.yaml
+++ b/charts/kcrypt-challenger/Chart.yaml
@@ -7,5 +7,5 @@ home: https://kairos.io/
 maintainers:
 - name: Ettore Di Giacinto
   email: mudler@kairos.io
-version: "0.4.0"
-appVersion: "v0.4.0"
+version: "0.6.0"
+appVersion: "v0.6.0"


### PR DESCRIPTION
To bring this in: https://github.com/kairos-io/kcrypt-challenger/pull/43